### PR TITLE
Update rocksdb version on deploy script

### DIFF
--- a/scripts/rocksdb/DEPLOY_MAVEN-rocksdb-armv7.sh
+++ b/scripts/rocksdb/DEPLOY_MAVEN-rocksdb-armv7.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VER=5.8.0
+VER=5.8.8
 
 M2_ROCKSDBJNI=$HOME/.m2/repository/org/rocksdb/rocksdbjni/$VER
 JARBALL=java/target/rocksdbjni-$VER-linux32.jar


### PR DESCRIPTION
RocksDB version has update on `BUILD-iri.sh` but this script was left behind